### PR TITLE
V0.8

### DIFF
--- a/config.yaml.copy
+++ b/config.yaml.copy
@@ -39,6 +39,11 @@ locale: "en-US"
 # Must have "relay_forwarded_message" enabled for this to work
 #regular_forwards: true
 
+# Limit (in days) for which a user can be inactive and still receive messages
+# If user is inactive, they will be kicked with an option to rejoin
+# Set to 0 to disable; disabled by default
+#inactivity_limit: 30
+
 # A list of ranks recognized by the bot
 # To add a rank, add a new entry and define the name, value, and permissisons
 # 

--- a/config.yaml.copy
+++ b/config.yaml.copy
@@ -43,8 +43,8 @@ locale: "en-US"
 # To add a rank, add a new entry and define the name, value, and permissisons
 # 
 # The following permissions are available: 
-# users upvote downvote promote promote_lower promote_same demote sign tsign ranksay 
-# ranksay_lower warn delete uncooldown remove purge blacklist motd_set ranked_info
+# users upvote downvote promote promote_lower promote_same demote sign tsign spoiler
+# ranksay ranksay_lower warn delete uncooldown remove purge blacklist motd_set ranked_info
 ranks:
   - name: "Banned"
     value: -10

--- a/config.yaml.copy
+++ b/config.yaml.copy
@@ -34,6 +34,11 @@ locale: "en-US"
 # Allow users to send photos, videos, or GIFs with a spoiler overlay
 #allow_media_spoilers: true
 
+# Relay forwarded messages as if they were a regular message
+# This will prepend the message text with a "Forwarded From" header and a link to the original message.
+# Must have "relay_forwarded_message" enabled for this to work
+#regular_forwards: true
+
 # A list of ranks recognized by the bot
 # To add a rank, add a new entry and define the name, value, and permissisons
 # 

--- a/config.yaml.copy
+++ b/config.yaml.copy
@@ -44,6 +44,14 @@ locale: "en-US"
 # Set to 0 to disable; disabled by default
 #inactivity_limit: 30
 
+# Map of chats and links that a user can refer to in their message
+# e.g., >>>/foo/ woulb be turned into an inline link to http://t.me/foochatbot
+#linked_network:
+#  foo: foochatbot
+#  bar: barchatbot
+# Alternatively, the map can be loaded from another YAML file using this syntax:
+#linked_network: "./somewhere/bots.yml"
+
 # A list of ranks recognized by the bot
 # To add a rank, add a new entry and define the name, value, and permissisons
 # 

--- a/config.yaml.copy
+++ b/config.yaml.copy
@@ -94,6 +94,7 @@ enable_uncooldown: [true, false]
 enable_remove: [true, false]
 enable_purge: [true, false]
 enable_blacklist: [true, false]
+enable_spoiler: [false, false]
 
 # Relaying toggles
 # Set any to false to disable relaying messages of that type

--- a/locales/en-GB-MDV2.yaml
+++ b/locales/en-GB-MDV2.yaml
@@ -340,6 +340,10 @@ command_descriptions:
  - |-
    Delete all messages from all blacklisted users
 
+# spoiler
+ - |-
+   Hides a media message with a spoiler
+
 # blacklist
  - |-
    Ban a user from the chat
@@ -410,6 +414,14 @@ logs:
 # reason_prefix
  - |-
    for: 
+
+# spoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, added a spoiler to receiver message [#{msid}]
+
+# unspoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, removed a spoiler from receiver message [#{msid}]
 
 # ranked_message: id, name, rank, text
  - |-

--- a/locales/en-GB-MDV2.yaml
+++ b/locales/en-GB-MDV2.yaml
@@ -249,6 +249,10 @@ replies:
 # purge_complete: msgs_deleted
  - |-
     _#{msgs_deleted} messages were matched and deleted\._
+ 
+# inactive
+ - |-
+    _You have been kicked due to inactivity\. Type /start to receive messages again\!_
 
 # success
  - |-

--- a/locales/en-GB-MDV2.yaml
+++ b/locales/en-GB-MDV2.yaml
@@ -3,8 +3,8 @@
 time_units: ['w', 'd', 'h', 'm', 's']
 
 # Format for timestamps
-# Currently in the form "MM-DD-YY" with 12 hour time and showing timzeone/offset name
-time_format: "%m-%d-%y %r %Z"
+# Currently in the form "DD/MM/YY" with 24 hour time and showing timzeone/offset name
+time_format: "%d/%m/%y %T %Z"
 
 # Term for off and on, respectively
 toggle: ["disabled", "enabled"]
@@ -16,166 +16,166 @@ toggle: ["disabled", "enabled"]
 replies:
 # joined
  - |-
-    <i>Welcome to the chat!</i>
+    _Welcome to the chat\!_
 
 # rejoined
  - |-
-    <i>You rejoined the chat!</i>
+    _You rejoined the chat\!_
 
 # left
  - |-
-    <i>You left the chat.</i>
+    _You left the chat\._
 
 # already_in_chat
  - |-
-    <i>You're already in the chat.</i>
+    _You're already in the chat\._
 
 # registration_closed 
  - |-
-    <i>Registration is closed. Check back later.</i>
+    _Registration is closed\. Check back later\._
 
 # not_in_chat
  - |-
-    <i>You're not in this chat! Type /start to join.</i>
+    _You're not in this chat\! Type /start to join\._
 
 # not_in_cooldown
  - |-
-    <i>User found, but the user was not in cooldown!</i>
+    _User found, but the user was not in cooldown\!_
 
 # rejected_message
  - |-
-    <i>Your message was not relayed because it contained a special font.</i>
+    _Your message was not relayed because it contained a special font\._
 
 # deanon_poll
  - |-
-    <i>Your poll was not sent because it does not allow anonymous voting.</i>
+    _Your poll was not sent because it does not allow anonymous voting\._
 
 # missing_args
  - |-
-    <i>You need to give an input to use this command.</i>
+    _You need to give an input to use this command\._
 
 # command_disabled
  - |-
-    <i>This command is disabled.</i>
+    _This command is disabled\._
 
 # media_disabled: type
  - |-
-    <i>Messages of type <code>#{type}</code> are disabled.</i>
+   _Messages of type `#{type}` are disabled\._
 
 # no_reply
  - |-
-    <i>You need to reply to a message to use this command.</i>
+    _You need to reply to a message to use this command\._
 
 # not_in_cache
  - |-
-    <i>That message could not be found in the cache.</i>
+    _That message could not be found in the cache\._
 
 # no_tripcode_set
  - |-
-    <i>You do not have a tripcode set.
-    Use the /tripcode command to set one.</i>
+    _You do not have a tripcode set\.
+    Use the /tripcode command to set one\._
 
 # no_user_found
  - |-
-    <i>There was no user found with that name.</i>
+    _There was no user found with that name\._
 
 # no_user_oid_found
  - |-
-    <i>There was no user found with that OID.</i>
+    _There was no user found with that OID\._
 
 # no_rank_found: ranks
  - |-
-    <i>There was no rank found with that name. Ranks are: [#{ranks}]</i>
+    _There was no rank found with that name\. Ranks are: [#{ranks}]_
 
 # promoted: rank
  - |-
-    <i>You have been promoted to #{rank}! Type /help to view the commands available to you.</i>
+    _You have been promoted to #{rank}\! Type /help to view the commands available to you\._
 
 # help_header
  - |-
-    <u><b>General Commands</b></u>
+    __*General Commands*__
 
 # help_rank_commands: rank
  - |-
-    <u><b>Commands available to #{rank}</b></u>
+    __*Commands available to #{rank}*__
 
 # help_reply_commands
  - |-
-    <u><b>Commands that require a reply</b></u>
+    __*Commands that require a reply*__
 
 # toggle_karma: toggle
  - |-
-    <b>Karma notifications</b>: #{toggle}
+    *Karma notifications*: #{toggle}
 
 # toggle_debug: toggle
  - |-
-    <b>Debug mode</b>: #{toggle}
+    *Debug mode*: #{toggle}
 
 # gave_upvote
  - |-
-    <i>You upvoted this message!</i>
+    _You upvoted this message\!_
 
 # got_upvote
  - |-
-    <i>You've just been upvoted! (check /info to see your karma or /toggleKarma to turn these notifications off)</i>
+    _You've just been upvoted\! \(check /info to see your karma or /toggleKarma to turn these notifications off\)_
 
 # upvoted_own_message
  - |-
-    <i>You can't upvote your own message!</i>
+    _You can't upvote your own message\!_
 
 # already_voted
  - |-
-    <i>You have already upvoted or downvoted this message.</i>
+    _You have already upvoted or downvoted this message\._
 
 # gave_downvote
  - |-
-    <i>You downvoted this message!</i>
+    _You downvoted this message\!_
 
 # got_downvote
  - |-
-    <i>You've just been downvoted! (check /info to see your karma or /toggleKarma to turn these notifications off)</i>
+    _You've just been downvoted\! \(check /info to see your karma or /toggleKarma to turn these notifications off\)_
 
 # downvoted_own_message
  - |-
-    <i>You can't downvote your own message!</i>
+    _You can't downvote your own message\!_
 
 # already_warned
  - |-
-    <i>This message has already been warned.</i>
+    _This message has already been warned\._
 
 # private_sign
  - |-
-    <i>Your account's forward privacy must be set to "Everybody" to sign with your username.</i>
+    _Your account's forward privacy must be set to "Everybody" to sign with your username\._
 
 # spamming
  - |-
-    <i>Your message has not been sent, avoid sending messages too fast. Try again later.</i>
+    _Your message has not been sent, avoid sending messages too fast\. Try again later\._
 
 # sign_spam
  - |-
-    <i>Your message has not been sent, avoid signing too often. Try again later.</i>
+    _Your message has not been sent, avoid signing too often\. Try again later\._
 
 # upvote_spam
  - |-
-    <i>You can't upvote at this time, avoid upvoting too often. Try again later.</i>
+    _You can't upvote at this time, avoid upvoting too often\. Try again later\._
 
 # downvote_spam
  - |-
-    <i>Your can't downvote at this time, avoid downvoting too often. Try again later.</i>
+    _Your can't downvote at this time, avoid downvoting too often\. Try again later\._
 
 # invalid_tripcode_format
  - |-
-    <i>Invalid tripcode format. The format is:</i>
-    <code>name#pass</code>
+    _Invalid tripcode format\. The format is:_
+    `name#pass`
 
 # tripcode_set: name, tripcode
  - |-
-    <i>Tripcode set. It will appear as:</i>
-    <b>#{name}</b> <code>#{tripcode}</code>:
+    _Tripcode set\. It will appear as:_
+    *#{name}* `#{tripcode}`:
 
 # tripcode_info: tripcode
  - |-
-    <b>Tripcode</b>: <code>#{tripcode}</code>
+    *Tripcode*: `#{tripcode}`
 
 # tripcode_unset
  - |-
@@ -183,20 +183,20 @@ replies:
 
 # user_info: oid, username, rank, rank_val, karma, warnings, smiley, warn_expiry, cooldown_until
  - |-
-    <b>id</b>: #{oid}, <b>username</b>: #{username}, <b>rank</b>: #{rank_val} (#{rank})
-    <b>karma</b>: #{karma}
-    <b>warnings</b>: #{warnings} #{smiley} #{warn_expiry}
-    <b>cooldown</b>: #{cooldown_until}
+    *id*: #{oid}, *username*: #{username}, *rank*: #{rank_val} \(#{rank}\)
+    *karma*: #{karma}
+    *warnings*: #{warnings} #{smiley} #{warn_expiry}
+    *cooldown*: #{cooldown_until}
 
 # info_warning: warn_expiry
  - |-
-    (one warning will expire at #{warn_expiry})
+    \(one warning will expire at #{warn_expiry}\)
 
 # ranked_info: oid, karma, cooldown_until
  - |-
-    <b>id</b>: #{oid}, <b>username</b>: anonymous, <b>rank</b>: n/a
-    <b>karma</b>: #{karma}
-    <b>cooldown</b>: #{cooldown_until}
+    *id*: #{oid}, *username*: anonymous, *rank*: n/a
+    *karma*: #{karma}
+    *cooldown*: #{cooldown_until}
 
 # cooldown_true
  - |-
@@ -207,40 +207,40 @@ replies:
 
 # user_count: total
  - |-
-    <b>#{total}</b> <i>users</i>
+    *#{total}* _users_
 
 # user_count_full: joined, left, blacklisted, total
  - |-
-    <b>#{joined}</b> <i>joined,</i> <b>#{left}</b> <i>left,</i> <b>#{blacklisted}</b> <i>blacklisted users</i> (<i>total</i>: <b>#{total}</b>)
+    *#{joined}* _joined,_ *#{left}* _left,_ *#{blacklisted}* _blacklisted users_ \(_total_: *#{total}*\)
 
 # message_deleted: reason, duration
  - |-
-    <i>This message has been deleted#{reason}. You have been given a cooldown of #{duration}.</i>
+    _This message has been deleted#{reason}\. You have been given a cooldown of #{duration}\._
 
 # message_removed: reason
  - |-
-    <i>This message has been removed#{reason}. No cooldown has been given, but please refrain from posting the same message again.</i>
+    _This message has been removed#{reason}\. No cooldown has been given, but please refrain from posting the same message again\._
 
 # reason_prefix
  - |-
-     for: 
+    \ for: 
 
 # cooldown_given: duration, reason
  - |-
-    <i>You've been given a cooldown of #{duration}#{reason}</i>
+    _You've been given a cooldown of #{duration}#{reason}_
 
 # on_cooldown: time
  - |-
-    <i>You're on cooldown until #{time}</i>
+    _You're on cooldown until #{time}_
 
 # media_limit: total
  - |-
-    <i>You cannot send media or forward messages at this time, try again in #{total} hours.</i>
+    _You cannot send media or forward messages at this time, try again in #{total} hours\._
 
 # blacklisted: reason
  - |-
-    <i>You have been blacklisted#{reason}
-    #{contact}</i>
+    _You have been blacklisted#{reason}
+    #{contact}_
 
 # blacklist_contact: contact
  - |-
@@ -248,7 +248,7 @@ replies:
 
 # purge_complete: msgs_deleted
  - |-
-    <i>#{msgs_deleted} messages were matched and deleted.</i>
+    _#{msgs_deleted} messages were matched and deleted\._
 
 # success
  - |-

--- a/locales/en-GB.yaml
+++ b/locales/en-GB.yaml
@@ -340,6 +340,10 @@ command_descriptions:
  - |-
    Delete all messages from all blacklisted users
 
+# spoiler
+ - |-
+   Hides a media message with a spoiler
+
 # blacklist
  - |-
    Ban a user from the chat
@@ -410,6 +414,14 @@ logs:
 # reason_prefix
  - |-
    for: 
+
+# spoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, added a spoiler to receiver message [#{msid}]
+
+# unspoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, removed a spoiler from receiver message [#{msid}]
 
 # ranked_message: id, name, rank, text
  - |-

--- a/locales/en-GB.yaml
+++ b/locales/en-GB.yaml
@@ -16,166 +16,166 @@ toggle: ["disabled", "enabled"]
 replies:
 # joined
  - |-
-    _Welcome to the chat\!_
+    <i>Welcome to the chat!</i>
 
 # rejoined
  - |-
-    _You rejoined the chat\!_
+    <i>You rejoined the chat!</i>
 
 # left
  - |-
-    _You left the chat\._
+    <i>You left the chat.</i>
 
 # already_in_chat
  - |-
-    _You're already in the chat\._
+    <i>You're already in the chat.</i>
 
 # registration_closed 
  - |-
-    _Registration is closed\. Check back later\._
+    <i>Registration is closed. Check back later.</i>
 
 # not_in_chat
  - |-
-    _You're not in this chat\! Type /start to join\._
+    <i>You're not in this chat! Type /start to join.</i>
 
 # not_in_cooldown
  - |-
-    _User found, but the user was not in cooldown\!_
+    <i>User found, but the user was not in cooldown!</i>
 
 # rejected_message
  - |-
-    _Your message was not relayed because it contained a special font\._
+    <i>Your message was not relayed because it contained a special font.</i>
 
 # deanon_poll
  - |-
-    _Your poll was not sent because it does not allow anonymous voting\._
+    <i>Your poll was not sent because it does not allow anonymous voting.</i>
 
 # missing_args
  - |-
-    _You need to give an input to use this command\._
+    <i>You need to give an input to use this command.</i>
 
 # command_disabled
  - |-
-    _This command is disabled\._
+    <i>This command is disabled.</i>
 
 # media_disabled: type
  - |-
-   _Messages of type `#{type}` are disabled\._
+    <i>Messages of type <code>#{type}</code> are disabled.</i>
 
 # no_reply
  - |-
-    _You need to reply to a message to use this command\._
+    <i>You need to reply to a message to use this command.</i>
 
 # not_in_cache
  - |-
-    _That message could not be found in the cache\._
+    <i>That message could not be found in the cache.</i>
 
 # no_tripcode_set
  - |-
-    _You do not have a tripcode set\.
-    Use the /tripcode command to set one\._
+    <i>You do not have a tripcode set.
+    Use the /tripcode command to set one.</i>
 
 # no_user_found
  - |-
-    _There was no user found with that name\._
+    <i>There was no user found with that name.</i>
 
 # no_user_oid_found
  - |-
-    _There was no user found with that OID\._
+    <i>There was no user found with that OID.</i>
 
 # no_rank_found: ranks
  - |-
-    _There was no rank found with that name\. Ranks are: [#{ranks}]_
+    <i>There was no rank found with that name. Ranks are: [#{ranks}]</i>
 
 # promoted: rank
  - |-
-    _You have been promoted to #{rank}\! Type /help to view the commands available to you\._
+    <i>You have been promoted to #{rank}! Type /help to view the commands available to you.</i>
 
 # help_header
  - |-
-    __*General Commands*__
+    <u><b>General Commands</b></u>
 
 # help_rank_commands: rank
  - |-
-    __*Commands available to #{rank}*__
+    <u><b>Commands available to #{rank}</b></u>
 
 # help_reply_commands
  - |-
-    __*Commands that require a reply*__
+    <u><b>Commands that require a reply</b></u>
 
 # toggle_karma: toggle
  - |-
-    *Karma notifications*: #{toggle}
+    <b>Karma notifications</b>: #{toggle}
 
 # toggle_debug: toggle
  - |-
-    *Debug mode*: #{toggle}
+    <b>Debug mode</b>: #{toggle}
 
 # gave_upvote
  - |-
-    _You upvoted this message\!_
+    <i>You upvoted this message!</i>
 
 # got_upvote
  - |-
-    _You've just been upvoted\! \(check /info to see your karma or /toggleKarma to turn these notifications off\)_
+    <i>You've just been upvoted! (check /info to see your karma or /toggleKarma to turn these notifications off)</i>
 
 # upvoted_own_message
  - |-
-    _You can't upvote your own message\!_
+    <i>You can't upvote your own message!</i>
 
 # already_voted
  - |-
-    _You have already upvoted or downvoted this message\._
+    <i>You have already upvoted or downvoted this message.</i>
 
 # gave_downvote
  - |-
-    _You downvoted this message\!_
+    <i>You downvoted this message!</i>
 
 # got_downvote
  - |-
-    _You've just been downvoted\! \(check /info to see your karma or /toggleKarma to turn these notifications off\)_
+    <i>You've just been downvoted! (check /info to see your karma or /toggleKarma to turn these notifications off)</i>
 
 # downvoted_own_message
  - |-
-    _You can't downvote your own message\!_
+    <i>You can't downvote your own message!</i>
 
 # already_warned
  - |-
-    _This message has already been warned\._
+    <i>This message has already been warned.</i>
 
 # private_sign
  - |-
-    _Your account's forward privacy must be set to "Everybody" to sign with your username\._
+    <i>Your account's forward privacy must be set to "Everybody" to sign with your username.</i>
 
 # spamming
  - |-
-    _Your message has not been sent, avoid sending messages too fast\. Try again later\._
+    <i>Your message has not been sent, avoid sending messages too fast. Try again later.</i>
 
 # sign_spam
  - |-
-    _Your message has not been sent, avoid signing too often\. Try again later\._
+    <i>Your message has not been sent, avoid signing too often. Try again later.</i>
 
 # upvote_spam
  - |-
-    _You can't upvote at this time, avoid upvoting too often\. Try again later\._
+    <i>You can't upvote at this time, avoid upvoting too often. Try again later.</i>
 
 # downvote_spam
  - |-
-    _Your can't downvote at this time, avoid downvoting too often\. Try again later\._
+    <i>Your can't downvote at this time, avoid downvoting too often. Try again later.</i>
 
 # invalid_tripcode_format
  - |-
-    _Invalid tripcode format\. The format is:_
-    `name#pass`
+    <i>Invalid tripcode format. The format is:</i>
+    <code>name#pass</code>
 
 # tripcode_set: name, tripcode
  - |-
-    _Tripcode set\. It will appear as:_
-    *#{name}* `#{tripcode}`:
+    <i>Tripcode set. It will appear as:</i>
+    <b>#{name}</b> <code>#{tripcode}</code>:
 
 # tripcode_info: tripcode
  - |-
-    *Tripcode*: `#{tripcode}`
+    <b>Tripcode</b>: <code>#{tripcode}</code>
 
 # tripcode_unset
  - |-
@@ -183,20 +183,20 @@ replies:
 
 # user_info: oid, username, rank, rank_val, karma, warnings, smiley, warn_expiry, cooldown_until
  - |-
-    *id*: #{oid}, *username*: #{username}, *rank*: #{rank_val} \(#{rank}\)
-    *karma*: #{karma}
-    *warnings*: #{warnings} #{smiley} #{warn_expiry}
-    *cooldown*: #{cooldown_until}
+    <b>id</b>: #{oid}, <b>username</b>: #{username}, <b>rank</b>: #{rank_val} (#{rank})
+    <b>karma</b>: #{karma}
+    <b>warnings</b>: #{warnings} #{smiley} #{warn_expiry}
+    <b>cooldown</b>: #{cooldown_until}
 
 # info_warning: warn_expiry
  - |-
-    \(one warning will expire at #{warn_expiry}\)
+    (one warning will expire at #{warn_expiry})
 
 # ranked_info: oid, karma, cooldown_until
  - |-
-    *id*: #{oid}, *username*: anonymous, *rank*: n/a
-    *karma*: #{karma}
-    *cooldown*: #{cooldown_until}
+    <b>id</b>: #{oid}, <b>username</b>: anonymous, <b>rank</b>: n/a
+    <b>karma</b>: #{karma}
+    <b>cooldown</b>: #{cooldown_until}
 
 # cooldown_true
  - |-
@@ -207,40 +207,40 @@ replies:
 
 # user_count: total
  - |-
-    *#{total}* _users_
+    <b>#{total}</b> <i>users</i>
 
 # user_count_full: joined, left, blacklisted, total
  - |-
-    *#{joined}* _joined,_ *#{left}* _left,_ *#{blacklisted}* _blacklisted users_ \(_total_: *#{total}*\)
+    <b>#{joined}</b> <i>joined,</i> <b>#{left}</b> <i>left,</i> <b>#{blacklisted}</b> <i>blacklisted users</i> (<i>total</i>: <b>#{total}</b>)
 
 # message_deleted: reason, duration
  - |-
-    _This message has been deleted#{reason}\. You have been given a cooldown of #{duration}\._
+    <i>This message has been deleted#{reason}. You have been given a cooldown of #{duration}.</i>
 
 # message_removed: reason
  - |-
-    _This message has been removed#{reason}\. No cooldown has been given, but please refrain from posting the same message again\._
+    <i>This message has been removed#{reason}. No cooldown has been given, but please refrain from posting the same message again.</i>
 
 # reason_prefix
  - |-
-    \ for: 
+     for: 
 
 # cooldown_given: duration, reason
  - |-
-    _You've been given a cooldown of #{duration}#{reason}_
+    <i>You've been given a cooldown of #{duration}#{reason}</i>
 
 # on_cooldown: time
  - |-
-    _You're on cooldown until #{time}_
+    <i>You're on cooldown until #{time}</i>
 
 # media_limit: total
  - |-
-    _You cannot send media or forward messages at this time, try again in #{total} hours\._
+    <i>You cannot send media or forward messages at this time, try again in #{total} hours.</i>
 
 # blacklisted: reason
  - |-
-    _You have been blacklisted#{reason}
-    #{contact}_
+    <i>You have been blacklisted#{reason}
+    #{contact}</i>
 
 # blacklist_contact: contact
  - |-
@@ -248,7 +248,7 @@ replies:
 
 # purge_complete: msgs_deleted
  - |-
-    _#{msgs_deleted} messages were matched and deleted\._
+    <i>#{msgs_deleted} messages were matched and deleted.</i>
 
 # success
  - |-

--- a/locales/en-GB.yaml
+++ b/locales/en-GB.yaml
@@ -250,6 +250,10 @@ replies:
  - |-
     <i>#{msgs_deleted} messages were matched and deleted.</i>
 
+# inactive
+ - |-
+    <i>You have been kicked due to inactivity. Type /start to receive messages again!</i>
+
 # success
  - |-
    ✅ 

--- a/locales/en-US-MDV2.yaml
+++ b/locales/en-US-MDV2.yaml
@@ -340,6 +340,10 @@ command_descriptions:
  - |-
    Delete all messages from all blacklisted users
 
+# spoiler
+ - |-
+   Hides a media message with a spoiler
+
 # blacklist
  - |-
    Ban a user from the chat
@@ -410,6 +414,14 @@ logs:
 # reason_prefix
  - |-
    for: 
+
+# spoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, added a spoiler to receiver message [#{msid}]
+
+# unspoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, removed a spoiler from receiver message [#{msid}]
 
 # ranked_message: id, name, rank, text
  - |-

--- a/locales/en-US-MDV2.yaml
+++ b/locales/en-US-MDV2.yaml
@@ -16,166 +16,166 @@ toggle: ["disabled", "enabled"]
 replies:
 # joined
  - |-
-    <i>Welcome to the chat!</i>
+    _Welcome to the chat\!_
 
 # rejoined
  - |-
-    <i>You rejoined the chat!</i>
+    _You rejoined the chat\!_
 
 # left
  - |-
-    <i>You left the chat.</i>
+    _You left the chat\._
 
 # already_in_chat
  - |-
-    <i>You're already in the chat.</i>
+    _You're already in the chat\._
 
 # registration_closed 
  - |-
-    <i>Registration is closed. Check back later.</i>
+    _Registration is closed\. Check back later\._
 
 # not_in_chat
  - |-
-    <i>You're not in this chat! Type /start to join.</i>
+    _You're not in this chat\! Type /start to join\._
 
 # not_in_cooldown
  - |-
-    <i>User found, but the user was not in cooldown!</i>
+    _User found, but the user was not in cooldown\!_
 
 # rejected_message
  - |-
-    <i>Your message was not relayed because it contained a special font.</i>
+    _Your message was not relayed because it contained a special font\._
 
 # deanon_poll
  - |-
-    <i>Your poll was not sent because it does not allow anonymous voting.</i>
+    _Your poll was not sent because it does not allow anonymous voting\._
 
 # missing_args
  - |-
-    <i>You need to give an input to use this command.</i>
+    _You need to give an input to use this command\._
 
 # command_disabled
  - |-
-    <i>This command is disabled.</i>
+    _This command is disabled\._
 
 # media_disabled: type
  - |-
-    <i>Messages of type <code>#{type}</code> are disabled.</i>
+   _Messages of type `#{type}` are disabled\._
 
 # no_reply
  - |-
-    <i>You need to reply to a message to use this command.</i>
+    _You need to reply to a message to use this command\._
 
 # not_in_cache
  - |-
-    <i>That message could not be found in the cache.</i>
+    _That message could not be found in the cache\._
 
 # no_tripcode_set
  - |-
-    <i>You do not have a tripcode set.
-    Use the /tripcode command to set one.</i>
+    _You do not have a tripcode set\.
+    Use the /tripcode command to set one\._
 
 # no_user_found
  - |-
-    <i>There was no user found with that name.</i>
+    _There was no user found with that name\._
 
 # no_user_oid_found
  - |-
-    <i>There was no user found with that OID.</i>
+    _There was no user found with that OID\._
 
 # no_rank_found: ranks
  - |-
-    <i>There was no rank found with that name. Ranks are: [#{ranks}]</i>
+    _There was no rank found with that name\. Ranks are: [#{ranks}]_
 
 # promoted: rank
  - |-
-    <i>You have been promoted to #{rank}! Type /help to view the commands available to you.</i>
+    _You have been promoted to #{rank}\! Type /help to view the commands available to you\._
 
 # help_header
  - |-
-    <u><b>General Commands</b></u>
+    __*General Commands*__
 
 # help_rank_commands: rank
  - |-
-    <u><b>Commands available to #{rank}</b></u>
+    __*Commands available to #{rank}*__
 
 # help_reply_commands
  - |-
-    <u><b>Commands that require a reply</b></u>
+    __*Commands that require a reply*__
 
 # toggle_karma: toggle
  - |-
-    <b>Karma notifications</b>: #{toggle}
+    *Karma notifications*: #{toggle}
 
 # toggle_debug: toggle
  - |-
-    <b>Debug mode</b>: #{toggle}
+    *Debug mode*: #{toggle}
 
 # gave_upvote
  - |-
-    <i>You upvoted this message!</i>
+    _You upvoted this message\!_
 
 # got_upvote
  - |-
-    <i>You've just been upvoted! (check /info to see your karma or /toggleKarma to turn these notifications off)</i>
+    _You've just been upvoted\! \(check /info to see your karma or /toggleKarma to turn these notifications off\)_
 
 # upvoted_own_message
  - |-
-    <i>You can't upvote your own message!</i>
+    _You can't upvote your own message\!_
 
 # already_voted
  - |-
-    <i>You have already upvoted or downvoted this message.</i>
+    _You have already upvoted or downvoted this message\._
 
 # gave_downvote
  - |-
-    <i>You downvoted this message!</i>
+    _You downvoted this message\!_
 
 # got_downvote
  - |-
-    <i>You've just been downvoted! (check /info to see your karma or /toggleKarma to turn these notifications off)</i>
+    _You've just been downvoted\! \(check /info to see your karma or /toggleKarma to turn these notifications off\)_
 
 # downvoted_own_message
  - |-
-    <i>You can't downvote your own message!</i>
+    _You can't downvote your own message\!_
 
 # already_warned
  - |-
-    <i>This message has already been warned.</i>
+    _This message has already been warned\._
 
 # private_sign
  - |-
-    <i>Your account's forward privacy must be set to "Everybody" to sign with your username.</i>
+    _Your account's forward privacy must be set to "Everybody" to sign with your username\._
 
 # spamming
  - |-
-    <i>Your message has not been sent, avoid sending messages too fast. Try again later.</i>
+    _Your message has not been sent, avoid sending messages too fast\. Try again later\._
 
 # sign_spam
  - |-
-    <i>Your message has not been sent, avoid signing too often. Try again later.</i>
+    _Your message has not been sent, avoid signing too often\. Try again later\._
 
 # upvote_spam
  - |-
-    <i>You can't upvote at this time, avoid upvoting too often. Try again later.</i>
+    _You can't upvote at this time, avoid upvoting too often\. Try again later\._
 
 # downvote_spam
  - |-
-    <i>Your can't downvote at this time, avoid downvoting too often. Try again later.</i>
+    _Your can't downvote at this time, avoid downvoting too often\. Try again later\._
 
 # invalid_tripcode_format
  - |-
-    <i>Invalid tripcode format. The format is:</i>
-    <code>name#pass</code>
+    _Invalid tripcode format\. The format is:_
+    `name#pass`
 
 # tripcode_set: name, tripcode
  - |-
-    <i>Tripcode set. It will appear as:</i>
-    <b>#{name}</b> <code>#{tripcode}</code>:
+    _Tripcode set\. It will appear as:_
+    *#{name}* `#{tripcode}`:
 
 # tripcode_info: tripcode
  - |-
-    <b>Tripcode</b>: <code>#{tripcode}</code>
+    *Tripcode*: `#{tripcode}`
 
 # tripcode_unset
  - |-
@@ -183,20 +183,20 @@ replies:
 
 # user_info: oid, username, rank, rank_val, karma, warnings, smiley, warn_expiry, cooldown_until
  - |-
-    <b>id</b>: #{oid}, <b>username</b>: #{username}, <b>rank</b>: #{rank_val} (#{rank})
-    <b>karma</b>: #{karma}
-    <b>warnings</b>: #{warnings} #{smiley} #{warn_expiry}
-    <b>cooldown</b>: #{cooldown_until}
+    *id*: #{oid}, *username*: #{username}, *rank*: #{rank_val} \(#{rank}\)
+    *karma*: #{karma}
+    *warnings*: #{warnings} #{smiley} #{warn_expiry}
+    *cooldown*: #{cooldown_until}
 
 # info_warning: warn_expiry
  - |-
-    (one warning will expire at #{warn_expiry})
+    \(one warning will expire at #{warn_expiry}\)
 
 # ranked_info: oid, karma, cooldown_until
  - |-
-    <b>id</b>: #{oid}, <b>username</b>: anonymous, <b>rank</b>: n/a
-    <b>karma</b>: #{karma}
-    <b>cooldown</b>: #{cooldown_until}
+    *id*: #{oid}, *username*: anonymous, *rank*: n/a
+    *karma*: #{karma}
+    *cooldown*: #{cooldown_until}
 
 # cooldown_true
  - |-
@@ -207,40 +207,40 @@ replies:
 
 # user_count: total
  - |-
-    <b>#{total}</b> <i>users</i>
+    *#{total}* _users_
 
 # user_count_full: joined, left, blacklisted, total
  - |-
-    <b>#{joined}</b> <i>joined,</i> <b>#{left}</b> <i>left,</i> <b>#{blacklisted}</b> <i>blacklisted users</i> (<i>total</i>: <b>#{total}</b>)
+    *#{joined}* _joined,_ *#{left}* _left,_ *#{blacklisted}* _blacklisted users_ \(_total_: *#{total}*\)
 
 # message_deleted: reason, duration
  - |-
-    <i>This message has been deleted#{reason}. You have been given a cooldown of #{duration}.</i>
+    _This message has been deleted#{reason}\. You have been given a cooldown of #{duration}\._
 
 # message_removed: reason
  - |-
-    <i>This message has been removed#{reason}. No cooldown has been given, but please refrain from posting the same message again.</i>
+    _This message has been removed#{reason}\. No cooldown has been given, but please refrain from posting the same message again\._
 
 # reason_prefix
  - |-
-     for: 
+    \ for: 
 
 # cooldown_given: duration, reason
  - |-
-    <i>You've been given a cooldown of #{duration}#{reason}</i>
+    _You've been given a cooldown of #{duration}#{reason}_
 
 # on_cooldown: time
  - |-
-    <i>You're on cooldown until #{time}</i>
+    _You're on cooldown until #{time}_
 
 # media_limit: total
  - |-
-    <i>You cannot send media or forward messages at this time, try again in #{total} hours.</i>
+    _You cannot send media or forward messages at this time, try again in #{total} hours\._
 
 # blacklisted: reason
  - |-
-    <i>You have been blacklisted#{reason}
-    #{contact}</i>
+    _You have been blacklisted#{reason}
+    #{contact}_
 
 # blacklist_contact: contact
  - |-
@@ -248,7 +248,7 @@ replies:
 
 # purge_complete: msgs_deleted
  - |-
-    <i>#{msgs_deleted} messages were matched and deleted.</i>
+    _#{msgs_deleted} messages were matched and deleted\._
 
 # success
  - |-

--- a/locales/en-US-MDV2.yaml
+++ b/locales/en-US-MDV2.yaml
@@ -249,6 +249,10 @@ replies:
 # purge_complete: msgs_deleted
  - |-
     _#{msgs_deleted} messages were matched and deleted\._
+   
+# inactive
+ - |-
+    _You have been kicked due to inactivity\. Type /start to receive messages again\!_
 
 # success
  - |-

--- a/locales/en-US.yaml
+++ b/locales/en-US.yaml
@@ -340,6 +340,10 @@ command_descriptions:
  - |-
    Delete all messages from all blacklisted users
 
+# spoiler
+ - |-
+   Hides a media message with a spoiler
+
 # blacklist
  - |-
    Ban a user from the chat
@@ -410,6 +414,14 @@ logs:
 # reason_prefix
  - |-
    for: 
+
+# spoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, added a spoiler to receiver message [#{msid}]
+
+# unspoiled: id, name, msid
+ - |-
+   User #{id}, aka #{name}, removed a spoiler from receiver message [#{msid}]
 
 # ranked_message: id, name, rank, text
  - |-

--- a/locales/en-US.yaml
+++ b/locales/en-US.yaml
@@ -250,6 +250,10 @@ replies:
  - |-
     <i>#{msgs_deleted} messages were matched and deleted.</i>
 
+# inactive
+ - |-
+    <i>You have been kicked due to inactivity. Type /start to receive messages again!</i>
+
 # success
  - |-
    ✅ 

--- a/src/privateparlor.cr
+++ b/src/privateparlor.cr
@@ -21,12 +21,15 @@ end
 # Start message sending routine
 spawn(name: "private_parlor_loop") do
   loop do
-    if msg = bot.queue.shift?
-      bot.send_messages(msg)
-    else
-      break unless bot.polling
-      Fiber.yield
-    end
+    break unless bot.polling
+
+    bot.send_messages()
+    sleep(0.5)
+  end
+
+  # Send last messages in queue
+  loop do 
+    break if bot.send_messages() == true
   end
 
   # Bot stopped polling from SIGINT/SIGTERM, shut down

--- a/src/privateparlor/config.cr
+++ b/src/privateparlor/config.cr
@@ -113,6 +113,9 @@ module Configuration
     @[YAML::Field(key: "enable_blacklist")]
     getter enable_blacklist : Array(Bool) = [true, false]
 
+    @[YAML::Field(key: "enable_spoiler")]
+    getter enable_spoiler : Array(Bool) = [false, false]
+
     # Relay Toggles
 
     @[YAML::Field(key: "relay_text")]
@@ -373,14 +376,15 @@ module Configuration
   # Returns an updated `Config` object
   def check_and_init_ranks(config : Config) : Config
     command_keys = Set{
-      :users, :upvote, :downvote, :promote, :promote_lower, :promote_same, :demote, :sign, :tsign, :ranksay,
-      :ranksay_lower, :warn, :delete, :uncooldown, :remove, :purge, :blacklist, :motd_set, :ranked_info
+      :users, :upvote, :downvote, :promote, :promote_lower, :promote_same, :demote, :sign, :tsign, :spoiler, :spoiler_own,
+      :ranksay, :ranksay_lower, :warn, :delete, :uncooldown, :remove, :purge, :blacklist, :motd_set, :ranked_info
     }
 
     promote_keys = Set{:promote, :promote_lower, :promote_same}
 
     ranksay_keys = Set{:ranksay, :ranksay_lower}
 
+    spoiler_keys = Set{:spoiler, :spoiler_own}
 
     config.intermediary_ranks.each do |ri|
       if (invalid = ri.permissions.to_set - command_keys.map(&.to_s)) && !invalid.empty?
@@ -399,6 +403,12 @@ module Configuration
           "Removed the following mutually exclusive permissions from Rank #{ri.name} (#{ri.value}): [#{invalid_ranksay.join(", ")}]" 
         }
         ri.permissions = ri.permissions - ranksay_keys.map(&.to_s)
+      end
+      if (invalid_spoiler = ri.permissions & spoiler_keys.map(&.to_s)) && invalid_spoiler.size > 1
+        Log.notice{
+          "Removed the following mutually exclusive permissions from Rank #{ri.name} (#{ri.value}): [#{invalid_spoiler.join(", ")}]" 
+        }
+        ri.permissions = ri.permissions - spoiler_keys.map(&.to_s)
       end
 
       config.ranks[ri.value] = Rank.new(

--- a/src/privateparlor/config.cr
+++ b/src/privateparlor/config.cr
@@ -33,6 +33,9 @@ module Configuration
     @[YAML::Field(key: "regular_forwards")]
     getter regular_forwards : Bool? = false
 
+    @[YAML::Field(key: "inactivity_limit")]
+    getter inactivity_limit : Int32 = 0
+
     @[YAML::Field(key: "ranks")]
     getter intermediary_ranks : Array(IntermediaryRank)
 

--- a/src/privateparlor/config.cr
+++ b/src/privateparlor/config.cr
@@ -376,15 +376,13 @@ module Configuration
   # Returns an updated `Config` object
   def check_and_init_ranks(config : Config) : Config
     command_keys = Set{
-      :users, :upvote, :downvote, :promote, :promote_lower, :promote_same, :demote, :sign, :tsign, :spoiler, :spoiler_own,
+      :users, :upvote, :downvote, :promote, :promote_lower, :promote_same, :demote, :sign, :tsign, :spoiler,
       :ranksay, :ranksay_lower, :warn, :delete, :uncooldown, :remove, :purge, :blacklist, :motd_set, :ranked_info
     }
 
     promote_keys = Set{:promote, :promote_lower, :promote_same}
 
     ranksay_keys = Set{:ranksay, :ranksay_lower}
-
-    spoiler_keys = Set{:spoiler, :spoiler_own}
 
     config.intermediary_ranks.each do |ri|
       if (invalid = ri.permissions.to_set - command_keys.map(&.to_s)) && !invalid.empty?
@@ -403,12 +401,6 @@ module Configuration
           "Removed the following mutually exclusive permissions from Rank #{ri.name} (#{ri.value}): [#{invalid_ranksay.join(", ")}]" 
         }
         ri.permissions = ri.permissions - ranksay_keys.map(&.to_s)
-      end
-      if (invalid_spoiler = ri.permissions & spoiler_keys.map(&.to_s)) && invalid_spoiler.size > 1
-        Log.notice{
-          "Removed the following mutually exclusive permissions from Rank #{ri.name} (#{ri.value}): [#{invalid_spoiler.join(", ")}]" 
-        }
-        ri.permissions = ri.permissions - spoiler_keys.map(&.to_s)
       end
 
       config.ranks[ri.value] = Rank.new(

--- a/src/privateparlor/config.cr
+++ b/src/privateparlor/config.cr
@@ -30,6 +30,9 @@ module Configuration
     @[YAML::Field(key: "allow_media_spoilers")]
     getter allow_media_spoilers : Bool? = false
 
+    @[YAML::Field(key: "regular_forwards")]
+    getter regular_forwards : Bool? = false
+
     @[YAML::Field(key: "ranks")]
     getter intermediary_ranks : Array(IntermediaryRank)
 

--- a/src/privateparlor/database.cr
+++ b/src/privateparlor/database.cr
@@ -263,6 +263,10 @@ class Database
     db.query_all("SELECT * FROM users WHERE rank NOT IN (#{values.join(", ") {"?"}})", args: values, as: User)
   end
 
+  def get_inactive_users(limit : Int32) Array(User) | Nil
+    db.query_all("SELECT * FROM users WHERE left is NULL AND lastActive < ?", (Time.utc - limit.days), as: User)
+  end
+
   # Queries the database for a user with a given *username*.
   #
   # Returns a `User` object or Nil if no user was found.

--- a/src/privateparlor/database.cr
+++ b/src/privateparlor/database.cr
@@ -472,10 +472,11 @@ class DatabaseHistory
   # Get sender_id of a specific message group
   def get_sender_id(msid : Int64) : Int64 | Nil
     db.query_one?(
-      "SELECT senderID
+      "SELECT DISTINCT senderID
       FROM message_groups
-      JOIN receivers ON receivers.receiverMSID = ? AND receivers.messageGroupID = message_groups.messageGroupID",
-      msid,
+      JOIN receivers ON receivers.messageGroupID = message_groups.messageGroupID
+      WHERE receivers.receiverMSID = ? OR message_groups.messageGroupID = ?",
+      msid, msid,
       as: Int64
     )
   end

--- a/src/privateparlor/database.cr
+++ b/src/privateparlor/database.cr
@@ -292,8 +292,18 @@ class Database
   end
 
   # Queries the database for all user ids, ordered by highest ranking users first then most active users.
-  def get_prioritized_users : Array(Int64)
-    db.query_all("SELECT id FROM users WHERE left IS NULL ORDER BY rank DESC, lastActive DESC", &.read(Int64))
+  def get_prioritized_users(user : User) : Array(Int64)
+    if user.debug_enabled
+      db.query_all("SELECT id FROM users WHERE left IS NULL ORDER BY rank DESC, lastActive DESC", &.read(Int64))
+    else
+      db.query_all("SELECT id 
+        FROM users 
+        WHERE left IS NULL AND id IS NOT ? 
+        ORDER BY rank DESC, lastActive DESC", 
+        args: [user.id]
+        &.read(Int64)
+      )
+    end
   end
 
   # Inserts a user with the given *id*, *username*, and *realname* into the database.

--- a/src/privateparlor/replies.cr
+++ b/src/privateparlor/replies.cr
@@ -64,12 +64,12 @@ class Replies
 
     log_keys = %i(
       start joined rejoined left promoted demoted warned message_deleted message_removed removed_cooldown
-      blacklisted reason_prefix ranked_message force_leave
+      blacklisted reason_prefix spoiled unspoiled ranked_message force_leave
     )
 
     command_keys = %i(
       start stop info users version upvote downvote toggle_karma toggle_debug tripcode promote demote
-      sign tsign ranksay warn delete uncooldown remove purge blacklist motd help motd_set ranked_info
+      sign tsign ranksay warn delete uncooldown remove purge spoiler blacklist motd help motd_set ranked_info
     )
 
     @entity_types = entities

--- a/src/privateparlor/replies.cr
+++ b/src/privateparlor/replies.cr
@@ -59,7 +59,7 @@ class Replies
       upvote_spam downvote_spam invalid_tripcode_format tripcode_set tripcode_info tripcode_unset 
       user_info info_warning ranked_info cooldown_true cooldown_false user_count user_count_full
       message_deleted message_removed reason_prefix cooldown_given on_cooldown media_limit blacklisted 
-      blacklist_contact purge_complete success fail
+      blacklist_contact purge_complete inactive success fail
     )
 
     log_keys = %i(

--- a/src/privateparlor/replies.cr
+++ b/src/privateparlor/replies.cr
@@ -285,6 +285,30 @@ class Replies
     Link.new("~~#{name}", "tg://user?id=#{id}").to_md
   end
 
+  def format_user_forward(name : String, id : Int64) : String
+    Group.new(Bold.new("Forwarded from "), Bold.new(UserMention.new(name, id))).to_md
+  end
+
+  def format_private_user_forward(name : String) : String
+    Group.new(Bold.new("Forwarded from "), Bold.new(Italic.new(name))).to_md
+  end
+
+  # For bots or public channels
+  def format_username_forward(name : String, username : String?, msid : Int64? = nil)
+    Group.new(
+      Bold.new("Forwarded from "), 
+      Bold.new(Link.new(name, "tg://resolve?domain=#{username}#{"&post=#{msid}" if msid}"))
+    ).to_md
+  end
+
+  # Removes the "-100" prefix for private channels
+  def format_private_channel_forward(name : String, id : Int64, msid : Int64?)
+    Group.new(
+      Bold.new("Forwarded from "), 
+      Bold.new(Link.new(name, "tg://privatepost?channel=#{id.to_s[4..]}#{"&post=#{msid}" if msid}"))
+    ).to_md
+  end
+
   # Returns a bolded signature showing which type of user sent this message.
   def format_user_say(signature : String) : String
     Bold.new("~~#{signature}").to_md

--- a/src/privateparlor/replies.cr
+++ b/src/privateparlor/replies.cr
@@ -135,7 +135,7 @@ class Replies
         end
 
         if replace
-          replace = replace.to_md
+          replace = replace.to_html
         end
         replace
       end
@@ -293,7 +293,7 @@ class Replies
 
   # Returns a link to the given user's account.
   def format_user_sign(id : Int64, name : String) : String
-    Link.new("~~#{name}", "tg://user?id=#{id}").to_md
+    Link.new("~~#{name}", "tg://user?id=#{id}").to_html
   end
 
   def format_user_forward(name : String, id : Int64, parsemode : Tourmaline::ParseMode) : String
@@ -342,12 +342,12 @@ class Replies
 
   # Returns a bolded signature showing which type of user sent this message.
   def format_user_say(signature : String) : String
-    Bold.new("~~#{signature}").to_md
+    Bold.new("~~#{signature}").to_html
   end
 
   # Returns a tripcode (Name!Tripcode) segment.
   def format_tripcode_sign(name : String, tripcode : String) : String
-    Group.new(Bold.new(name), Code.new(tripcode)).to_md
+    Group.new(Bold.new(name), Code.new(tripcode)).to_html
   end
 
   # Formats a timespan, so the duration is marked by its largest unit ("20m", "3h", "5d", etc)
@@ -390,12 +390,12 @@ class Replies
   #
   # Feel free to edit this if you fork the code.
   def version : String
-    Group.new("Private Parlor v#{VERSION} ~ ", Link.new("[Source]", "https://github.com/Charibdys/Private-Parlor")).to_md
+    Group.new("Private Parlor v#{VERSION} ~ ", Link.new("[Source]", "https://github.com/Charibdys/Private-Parlor")).to_html
   end
 
   # Returns a custom text from a given string.
   def custom(text : String) : String
-    Section.new(text).to_md
+    Section.new(text).to_html
   end
 
   # Returns a message containing the commands the user can use.
@@ -406,22 +406,22 @@ class Replies
     )
 
     reply_required_keys = %i(
-      upvote downvote warn delete 
+      upvote downvote warn delete spoiler
       remove blacklist ranked_info
     )
 
     help_text = String.build do |str|
       str << substitute_reply(:help_header)
-      str << "\n/start - #{@command_descriptions[:start]?}".to_md
-      str << "\n/stop - #{@command_descriptions[:stop]?}".to_md
-      str << "\n/info - #{@command_descriptions[:info]?}".to_md
-      str << "\n/users - #{@command_descriptions[:users]?}".to_md
-      str << "\n/version - #{@command_descriptions[:version]?}".to_md
-      str << "\n/toggle_karma - #{@command_descriptions[:toggle_karma]?}".to_md
-      str << "\n/toggle_debug - #{@command_descriptions[:toggle_debug]?}".to_md
-      str << "\n/tripcode - #{@command_descriptions[:tripcode]?}".to_md
-      str << "\n/motd - #{@command_descriptions[:motd]?}".to_md
-      str << "\n/help - #{@command_descriptions[:help]?}".to_md
+      str << "\n/start - #{@command_descriptions[:start]?}".to_html
+      str << "\n/stop - #{@command_descriptions[:stop]?}".to_html
+      str << "\n/info - #{@command_descriptions[:info]?}".to_html
+      str << "\n/users - #{@command_descriptions[:users]?}".to_html
+      str << "\n/version - #{@command_descriptions[:version]?}".to_html
+      str << "\n/toggle_karma - #{@command_descriptions[:toggle_karma]?}".to_html
+      str << "\n/toggle_debug - #{@command_descriptions[:toggle_debug]?}".to_html
+      str << "\n/tripcode - #{@command_descriptions[:tripcode]?}".to_html
+      str << "\n/motd - #{@command_descriptions[:motd]?}".to_html
+      str << "\n/help - #{@command_descriptions[:help]?}".to_html
 
       if rank = ranks[user.rank]?
         rank_commands = [] of String
@@ -466,12 +466,12 @@ class Replies
         if !rank_commands.empty?
           str << "\n\n"
           str << substitute_reply(:help_rank_commands, {"rank" => rank.name})
-          rank_commands.each {|line| str << "\n#{line}".to_md}
+          rank_commands.each {|line| str << "\n#{line}".to_html}
         end
         if !reply_commands.empty?
           str << "\n\n"
           str << substitute_reply(:help_reply_commands)
-          reply_commands.each {|line| str << "\n#{line}".to_md}
+          reply_commands.each {|line| str << "\n#{line}".to_html}
         end
       end
     end

--- a/src/privateparlor/telegram.cr
+++ b/src/privateparlor/telegram.cr
@@ -1270,7 +1270,7 @@ class PrivateParlor < Tourmaline::Client
     unless reply = message.reply_message
       return relay_to_one(message.message_id, user.id, :no_reply)
     end
-    if reply.forward_from || reply.forward_from_chat
+    if reply.forward_date
       return relay_to_one(message.message_id, user.id, :fail)
     end
     unless reply_user = database.get_user(@history.get_sender_id(reply.message_id))
@@ -1523,7 +1523,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless user = database.get_user(info.id)
@@ -1561,7 +1561,7 @@ class PrivateParlor < Tourmaline::Client
           return
         end
     {% end %}
-    if (message.forward_from || message.forward_from_chat)
+    if message.forward_date
       return
     end
     if message.media_group_id
@@ -1620,7 +1620,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless album = message.media_group_id
@@ -1692,7 +1692,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless poll = message.poll
@@ -1900,7 +1900,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless sticker = message.sticker
@@ -1933,7 +1933,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if (message.forward_from || message.forward_from_chat)
+    if message.forward_date
       return
     end
     unless user = database.get_user(info.id)
@@ -1963,7 +1963,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless venue = message.venue
@@ -2006,7 +2006,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless location = message.location
@@ -2043,7 +2043,7 @@ class PrivateParlor < Tourmaline::Client
     unless (message = update.message) && (info = message.from)
       return
     end
-    if message.forward_from || message.forward_from_chat
+    if message.forward_date
       return
     end
     unless contact = message.contact

--- a/src/privateparlor/telegram.cr
+++ b/src/privateparlor/telegram.cr
@@ -64,7 +64,7 @@ class PrivateParlor < Tourmaline::Client
     @history = get_history_type(db, config)
     @queue = Deque(QueuedMessage).new
     @queue_mutex = Mutex.new
-    @replies = Replies.new(config.entities, config.locale, config.smileys, config.blacklist_contact, config.salt)
+    @replies = Replies.new(config.entities, config.locale, config.smileys, config.blacklist_contact, config.salt, config.linked_network)
     @spam_handler = SpamScoreHandler.new(config) if config.spam_interval_seconds != 0
     @tasks = register_tasks(config.spam_interval_seconds)
     @albums = {} of String => Album

--- a/src/privateparlor/telegram.cr
+++ b/src/privateparlor/telegram.cr
@@ -1512,7 +1512,7 @@ class PrivateParlor < Tourmaline::Client
     @database.modify_user(user)
 
     if raw_caption = message.caption
-      caption = check_text(@replies.strip_format(raw_caption, message.entities), user, message.message_id)
+      caption = check_text(@replies.strip_format(raw_caption, message.caption_entities), user, message.message_id)
       if caption.nil? # Caption contained a special font or used a disabled command
         return
       end

--- a/src/privateparlor/telegram.cr
+++ b/src/privateparlor/telegram.cr
@@ -555,7 +555,7 @@ class PrivateParlor < Tourmaline::Client
         return relay_to_one(message.message_id, user.id, :fail)
       end
       unless reply_user = database.get_user(@history.get_sender_id(reply.message_id))
-        return
+        return relay_to_one(message.message_id, user.id, :not_in_cache)
       end
 
       user.set_active(info.username, info.full_name)
@@ -664,7 +664,7 @@ class PrivateParlor < Tourmaline::Client
       return relay_to_one(message.message_id, user.id, :no_reply)
     end
     unless reply_user = database.get_user(history_with_karma.get_sender_id(reply.message_id))
-      return
+      return relay_to_one(message.message_id, user.id, :not_in_cache)
     end
 
     user.set_active(info.username, info.full_name)
@@ -713,7 +713,7 @@ class PrivateParlor < Tourmaline::Client
       return relay_to_one(message.message_id, user.id, :no_reply)
     end
     unless reply_user = database.get_user(history_with_karma.get_sender_id(reply.message_id))
-      return
+      return relay_to_one(message.message_id, user.id, :not_in_cache)
     end
 
     user.set_active(info.username, info.full_name)


### PR DESCRIPTION
Added the following features with this version:

- Concurrency model was updated. CPU Utilization was dropped by about 99%
- Added "message not in cache" reply to applicable commands
- Messages with media (photos, videos, animations, etc) can be given a spoiler after being relayed. This only works for messages sent by the bot
- Inactive users can be kicked from the bot to reduce the number of messages sent in bursts. The limit for how long a user can be idle before being labelled inactive can be configured.
- Users can link to other bots using a 4chan style board redirect (e.g., >>>/bot/). The bots available with this feature can be configured.
- If toggled, forwarded messages can be relayed as a regular message. Messages sent this way will have their text or caption prepended with a header showing a link to the origin of that message.